### PR TITLE
Add @philsnow's tabsaver for Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | battery-time | Show the estimated battery life. |
 | change-wallpaper | If you have your desktop wallpaper set to rotate through a folder of images at intervals, this will force an immediate switch |
 | chrome | Force opening an URL with Chrome |
+| chrome-tabs | Outputs the URLs for all your open Chrome tabs so you can snapshot them |
 | clean-clipboard | Converts contents of clipboard to plain text. |
 | clear-macos-font-cache | Clears the macOS font cache, originally from [awesome-osx-command-line](https://github.com/herrbischoff/awesome-osx-command-line/blob/master/functions.md#app-icons) |
 | column-view | Set the current directory to column view in the Finder |

--- a/bin/chrome-tabs
+++ b/bin/chrome-tabs
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Originally by @philsnow on the xooglers slack
+
+if [ $(uname -a | grep -ci Darwin) != 1 ]; then
+  echo "Sorry, this script only works on macOS"
+  exit 1
+fi
+
+ts () {
+  date +'%Fz%T'
+}
+
+chrome_tabs () {
+  for win in $(seq 0 $(osascript -e 'tell application "Chrome" to get count every window'))
+  do
+    for tab in $(seq 0 $(osascript -e "tell application \"Chrome\" to get count every tab of window ${win}"))
+    do
+      echo -n "win $win tab $tab: "
+      osascript -e "tell application \"Chrome\" to get URL of tab $tab of window $win"
+    done
+  done
+}
+
+chrome_tabs


### PR DESCRIPTION
Chrome sometimes munches all your tabs when it crashes, this script lets
you capture all the urls & tabs you have open in Chrome.

Only works on MacOS since it relies on osascript.