### PR TITLE
Add script to change the Mojave disk space warning threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `safari` | Force opening an URL with Safari |
 | `screen-resolution` | Display the screen resolution |
 | `set-macos-hostname` | Set the macOS name of your machine. macOS may be UNIX-based, but the Apple eccentricities mean that no, `sudo hostname newname` isn't enough if you want the new name to be visible on the network for things like File and Screen sharing. |
+| `set-mojave-disk-warning-threshold` | Mojave now pops up a warning when you're running low on disk space. Unfortunately the threshold they pick triggers a warning every couple of minutes on my MacBook Air. This script lets you set a different number of free gigabytes to warn at. |
 | `speedup-apple-mail` | Speeds up Mail.app by vaccuuming the indexes - Originally from [http://www.hawkwings.net/2007/03/03/scripts-to-automate-the-mailapp-envelope-speed-trick/](http://www.hawkwings.net/2007/03/03/scripts-to-automate-the-mailapp-envelope-speed-trick/) |
 | `toggle-finder-show-dotfiles` | Toggle whether Finder shows dotfiles |
 | `unquarantine` | Unquarantine a file |

--- a/bin/set-mojave-disk-warning-threshold
+++ b/bin/set-mojave-disk-warning-threshold
@@ -28,7 +28,7 @@ if ! [[ "$1" =~ ^[0-9]+$ ]]; then
 fi
 
 defaults write com.apple.diskspaced minFreeSpace "${1}"
-sipError=$(launchctl unload -w "${DISKSPACE_D_PLIST}" 2>&1 | grep -i 'System Integrity Protection' | wc -l)
+sipError=$(launchctl unload -w "${DISKSPACE_D_PLIST}" 2>&1 | grep -i 'System Integrity Protection' -c)
 if [[ "$sipError" -eq 1 ]]; then
   echo "It looks like you have SIP enabled. It's ok, it's the default macOS setting and more secure."
   echo "You're going to have to reboot to get rid of those damn popups whining about disk space though."

--- a/bin/set-mojave-disk-warning-threshold
+++ b/bin/set-mojave-disk-warning-threshold
@@ -28,5 +28,9 @@ if ! [[ "$1" =~ ^[0-9]+$ ]]; then
 fi
 
 defaults write com.apple.diskspaced minFreeSpace "${1}"
-launchctl unload -w "${DISKSPACE_D_PLIST}"
+sipError=$(launchctl unload -w "${DISKSPACE_D_PLIST}" 2>&1 | grep -i 'System Integrity Protection' | wc -l)
+if [[ "$sipError" -eq 1 ]]; then
+  echo "It looks like you have SIP enabled. It's ok, it's the default macOS setting and more secure."
+  echo "You're going to have to reboot to get rid of those damn popups whining about disk space though."
+fi
 launchctl load -w "${DISKSPACE_D_PLIST}"

--- a/bin/set-mojave-disk-warning-threshold
+++ b/bin/set-mojave-disk-warning-threshold
@@ -9,6 +9,13 @@
 # This script allows you to set the warning threshold to a different number
 # of gigabytes of free space before Mojave whines at you.
 
+DISKSPACE_D_PLIST='/System/Library/LaunchAgents/com.apple.diskspaced.plist'
+
+if [[ ! -f $DISKSPACE_D_PLIST ]]; then
+  echo "No $DISKSPACE_D_PLIST, exiting"
+  exit 0
+fi
+
 if [[ $# -ne 1 ]]; then
   # shellcheck disable=SC2086
   echo "$(basename $0) takes a single argument, the minimum number of gigabytes of free space before complaining"
@@ -21,3 +28,5 @@ if ! [[ "$1" =~ ^[0-9]+$ ]]; then
 fi
 
 defaults write com.apple.diskspaced minFreeSpace "${1}"
+launchctl unload -w "${DISKSPACE_D_PLIST}"
+launchctl load -w "${DISKSPACE_D_PLIST}"

--- a/bin/set-mojave-disk-warning-threshold
+++ b/bin/set-mojave-disk-warning-threshold
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Joe Block <jpb@unixorn.net>
+# License: Apache 2.0
+#
+# Mojave has a pain in the ass warning about not enough disk being free, and
+# on my MBA, it pops up every few minutes. Fuck that noise.
+#
+# This script allows you to set the warning threshold to a different number
+# of gigabytes of free space before Mojave whines at you.
+
+if [[ $# -ne 1 ]]; then
+  echo "$(basename $0) takes a single argument, the minimum number of gigabytes of free space before complaining"
+  exit 1
+fi
+
+if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+  echo "You must specify an integer number of gigabytes free on disk to trigger the Mojave disk warning"
+  exit 1
+fi
+
+defaults write com.apple.diskspaced minFreeSpace "${1}"

--- a/bin/set-mojave-disk-warning-threshold
+++ b/bin/set-mojave-disk-warning-threshold
@@ -10,6 +10,7 @@
 # of gigabytes of free space before Mojave whines at you.
 
 if [[ $# -ne 1 ]]; then
+  # shellcheck disable=SC2086
   echo "$(basename $0) takes a single argument, the minimum number of gigabytes of free space before complaining"
   exit 1
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Mojave has a pain in the ass warning about not enough disk being free, and on my MBA, it pops up every few minutes. Fuck that noise.

Add `set-mojave-disk-warning-threshold` script that allows you to set the warning threshold to a different number of gigabytes of free space before Mojave whines at you.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
