### PR TITLE
Cope with WIFI captive portal mishandling by macOS

### DIFF
--- a/bin/unfuck-captive-portal
+++ b/bin/unfuck-captive-portal
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Sometimes macOS' captive portal detection shits the bed and won't render
+# the html for a wifi captive portal page, so you can't get onto WIFI.
+#
+# You can work around this by opening Apple's hotspot detection page
+# in Safari, so here's a command line tool to do so.
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+exec open -a "Safari" "http://captive.apple.com/hotspot-detect.html"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

Sometimes macOS' captive portal detection shits the bed and won't render the html for a wifi captive portal page, so you can't get onto WIFI.

You can work around this by opening Apple's hotspot detection page in Safari, so here's a command line tool to do so.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This repository is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
