### PR TITLE
Add dock bounce controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 ## About
 
-Tumult is an [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) compatible plugin that adds macOS-specific functions and scripts to your ZSH environment. Some of these are mine, and have an Apache 2.0 license, some of them were written by other people - the authors and licenses are embedded in those scripts.
+Tumult is an [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)-compatible plugin that adds macOS-specific functions and scripts to your ZSH environment.
+
+Some of these are mine, and have an Apache 2.0 license, some of them were written by other people - the authors and licenses are embedded in those scripts.
 
 Tumult will check to see if you're running on macOS and not add aliases or inject its bin into your `$PATH` if you aren't. This allows you to use the same plugin list in all your environments without polluting your `$PATH` with incompatible functions and scripts on your non-Apple machines.
 
@@ -42,12 +44,14 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `clear-macos-font-cache` | Clears the macOS font cache, originally from [awesome-osx-command-line](https://github.com/herrbischoff/awesome-osx-command-line/blob/master/functions.md#app-icons) |
 | `column-view` | Set the current directory to column view in the Finder |
 | `diceware-password` | Generate a random but memorable passphrase using the Diceware Passphrase Algorithm. See [http://world.std.com/~reinhold/diceware.html](http://world.std.com/~reinhold/diceware.html) |
+| `disable-bouncing-dock-icons` | Disable icons bouncing in your Dock |
 | `disable-ftp-server` | Disable the ftp server on a Mac |
 | `disable-ssh-server` | Disable the ssh server on a Mac |
 | `disable-startup-chime` | Disable the boot chime |
 | `disturb` | Re-enable notifications in Notification Center |
 | `do-not-disturb` | Stifle notifications in Notification Center |
 | `eject-all` | Eject all removable disks |
+| `enable-bouncing-dock-icons` | Enable icons bouncing in your Dock |
 | `enable-ftp-server` | Enable the ftp server on a Mac |
 | `enable-ssh-server` | Enable the ssh server on a Mac |
 | `enable-startup-chime` | Re-enable the boot chime |
@@ -94,7 +98,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 
 ## Other Useful macOS tools
 
-* [apple-touchbar](https://github.com/zsh-users/zsh-apple-touchbar) - ZSH plugin that adds MacBook Pro's touchbar support in iTerm2.
+* [apple-touchbar](https://github.com/zsh-users/zsh-apple-touchbar) - ZSH plugin that adds support for the MacBook Pro's touchbar to iTerm2.
 * [awesome-osx-command-line](https://github.com/herrbischoff/awesome-osx-command-line) documents many ways to manipulate macOS settings and applications from the command line.
 * [bash-snippets](https://github.com/unixorn/Bash-Snippets) - `brew`-installable set of handy command-line tools.
 * [desktoppr](https://github.com/scriptingosx/desktoppr) - A command line tool which can read and set the desktop picture.
@@ -103,7 +107,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 
 ## Installation
 
-Tumult is packaged as a ZSH plugin to make it easier to use if you're already using a ZSH framework. If you don't already use a framework, I recommend [zgen](https://github.com/tarjoilija/zgen), it is wicked fast and also supports using [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)'s internal plugins.
+Tumult is packaged as a ZSH plugin to make it easier to use if you're already using a ZSH framework. If you don't already use a framework, I recommend [zgen](https://github.com/tarjoilija/zgen), because it is wicked fast and also supports using [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)'s internal plugins.
 
 ### Bash / not using a framework
 
@@ -129,4 +133,4 @@ Add `zgen load unixorn/tumult.plugin.zsh` to your `.zshrc` file in the same func
 
 ## License
 
-Tumult is Apache 2.0 licensed, except for some scripts in bin that have other license statements inline.
+Tumult is Apache 2.0 licensed, except for some scripts in the bin directory that have other license statements embedded inline in their source.

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `mkicns` | Creates an .icns file from an image file |
 | `naptime` | Put the machine to sleep |
 | `nitenite` | Make a Mac go to sleep |
-| `pbcurl` | `curl` the address in the clipboard. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko/dotfiles) |
-| `pbindent` | Indent the contents of the clipboard 4 spaces. With -o, write result to standard output instead of to the clipboard. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko/dotfiles) |
-| `pbsed` | Run `sed`(1) on the contents of the clipboard and put the result back on the clipboard. All `sed` options and arguments are supported. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko/dotfiles) |
+| `pbcurl` | `curl` the address in the clipboard. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
+| `pbindent` | Indent the contents of the clipboard 4 spaces. With -o, write result to standard output instead of to the clipboard. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
+| `pbsed` | Run `sed`(1) on the contents of the clipboard and put the result back on the clipboard. All `sed` options and arguments are supported. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
 | `pledit` | Convert a plist to XML, run `${EDITOR}` on it, then convert it back. |
 | `safari` | Force opening an URL with Safari |
 | `screen-resolution` | Display the screen resolution |

--- a/bin/disable-bouncing-dock-icons
+++ b/bin/disable-bouncing-dock-icons
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Disable icon bouncing in the dock
+#
+# Copyright 2020, Joe Block <jpb@unixorn.net>
+
+set -o pipefail
+
+defaults write com.apple.dock no-bouncing -bool TRUE
+killall Dock

--- a/bin/enable-bouncing-dock-icons
+++ b/bin/enable-bouncing-dock-icons
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Enable bouncing dock icons
+#
+# Copyright 2020, Joe Block
+
+set -o pipefail
+
+defaults write com.apple.dock no-bouncing -bool FALSE
+killall Dock

--- a/bin/macos-menubar-dark
+++ b/bin/macos-menubar-dark
@@ -1,18 +1,1 @@
-#!/bin/bash
-#
-# Enable dark mode
-
-set -e
-
-if [[ "$(uname -s)" != 'Darwin' ]]; then
-  echo 'Sorry, this script only works on macOS'
-  exit 1
-fi
-
-exec osascript <<EOF
-tell application "System Events"
-  tell appearance preferences
-    set dark mode to true
-  end tell
-end tell
-EOF
+menubar-dark

--- a/bin/macos-menubar-light
+++ b/bin/macos-menubar-light
@@ -1,18 +1,1 @@
-#!/bin/bash
-#
-# Switch to light menubar
-
-set -e
-
-if [[ "$(uname -s)" != 'Darwin' ]]; then
-  echo 'Sorry, this script only works on macOS'
-  exit 1
-fi
-
-exec osascript <<EOF
-tell application "System Events"
-  tell appearance preferences
-    set dark mode to false
-  end tell
-end tell
-EOF
+menubar-light


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

* Add `disable-bouncing-dock-icons` and `enable-bouncing-dock-icons` to tumult
* Update macos-menubar-{dark,light} modes

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
