### PR TITLE
Add script to google search from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `focusmode-disable` | Turn off single-app mode |
 | `focusmode-enable` | Turn on single-app mode |
 | `get-iterm2-buffer` | Gets the current iterm2 window's scrollback contents |
+| `google` | Does a google search from the command line |
 | `icon-view` | Set the current directory to icon view in the Finder |
 | `imgcat` | Display an image directly in your terminal. Only works with iTerm 2 |
 | `itunesctl` | Play/Pause iTunes from terminal. |

--- a/bin/google
+++ b/bin/google
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [ "$(uname -a | grep -ci DARWIN)" != 1 ]; then
+  echo "Sorry, this script only works on macOS"
+  exit 1
+fi
+
+IFS='+'
+query="$*"
+
+open "https://www.google.com/#q=${query}"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

Add `google` - uses your default browser to do a google search that you specify from the command line.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
