### PR TITLE
Refactor commands out of jpb plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | ------ | ----------- |
 | `720p` | Resets an application's window to 720p (1280x720) for better screencasting. Doesn't work with apps that don't support window resizing in their AppleScript dictionary. Copied from Derrick Bailey's [blog](http://lostechies.com/derickbailey/2012/09/08/screencasting-tip-resize-your-app-to-720p-1280x720-in-osx/) |
 | `battery-percentage` | Show the percentage of battery charge |
+| `battery-prompt` | Prints battery status as a string suitable for embedding in a prompt. |
 | `battery-time` | Show the estimated battery life. |
 | `change-wallpaper` | If you have your desktop wallpaper set to rotate through a folder of images at intervals, this will force an immediate switch |
 | `clean-xml-clip` | Clean up the XML on the clipboard |
@@ -66,6 +67,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `focusmode-disable` | Turn off single-app mode |
 | `focusmode-enable` | Turn on single-app mode |
 | `get-iterm2-buffer` | Gets the current iterm2 window's scrollback contents |
+| `get-wifi-password` | Helper script to print the password for the wifi network you're connected to. |
 | `google` | Does a google search from the command line |
 | `icon-view` | Set the current directory to icon view in the Finder |
 | `imgcat` | Display an image directly in your terminal. Only works with iTerm 2 |
@@ -84,6 +86,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `mac-safesleep` | Set a Mac to use safesleep mode when sleeping |
 | `mac-sleep` | Set a Mac to use the default sleep mode when sleeping |
 | `macos-frontmost-app` | Shows what application is Frontmost. |
+| `markdown-open` | Converts a markdown file to html and opens it in your browser |
 | `menubar-dark` | Set the menubar to be white text on black background |
 | `menubar-light` | Set the menubar to the default black text on white background style |
 | `mkdmg` | Makes a .dmg file from a directory |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `google` | Does a google search from the command line |
 | `icon-view` | Set the current directory to icon view in the Finder |
 | `imgcat` | Display an image directly in your terminal. Only works with iTerm 2 |
+| `iterm` | Open a new `iTerm 2` session with the argument given |
 | `itunesctl` | Play/Pause iTunes from terminal. |
 | `keychainctl` | CRUD for secrets in your macOS keychain - from AriaFallah's [gist](https://gist.github.com/AriaFallah/fe7b651ba2652bd301334e011749e4b2/)|
 | `kick-afp` | Restart file sharing from the CLI. I got tired of having to remote desktop in to kick the fileserver via the GUI every time Apple's file sharing got wedged, now it can be fixed over `ssh` |

--- a/bin/battery-prompt
+++ b/bin/battery-prompt
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# coding=UTF-8
+#
+# http://stevelosh.com/blog/2010/02/my-extravagant-zsh-prompt/
+
+import math, subprocess
+
+p = subprocess.Popen(["ioreg", "-rc", "AppleSmartBattery"], stdout=subprocess.PIPE)
+output = p.communicate()[0]
+
+o_max = [l for l in output.splitlines() if 'MaxCapacity' in l][0]
+o_cur = [l for l in output.splitlines() if 'CurrentCapacity' in l][0]
+
+b_max = float(o_max.rpartition('=')[-1].strip())
+b_cur = float(o_cur.rpartition('=')[-1].strip())
+
+charge = b_cur / b_max
+charge_threshold = int(math.ceil(10 * charge))
+
+# Output
+
+total_slots, slots = 10, []
+filled = int(math.ceil(charge_threshold * (total_slots / 10.0))) * u'▸'
+empty = (total_slots - len(filled)) * u'▹'
+
+out = (filled + empty).encode('utf-8')
+import sys
+
+color_green = '%{[32m%}'
+color_yellow = '%{[1;33m%}'
+color_red = '%{[31m%}'
+color_reset = '%{[00m%}'
+color_out = (
+    color_green if len(filled) > 6
+    else color_yellow if len(filled) > 4
+    else color_red
+)
+
+out = color_out + out + color_reset
+sys.stdout.write(out)

--- a/bin/get-wifi-password
+++ b/bin/get-wifi-password
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Helper script to print the password for a wifi network on macOS
+#
+# Apache licensed.
+#
+# Copyright 2015 Joe Block <jpb@unixorn.net>
+#
+# This has only been tested on OS X 10.10 Yosemite since I don't have
+# anything older.
+
+if [[ "$(uname -s)" = "Darwin" ]]; then
+  security find-generic-password -ga "$1" 2>&1 | \
+    grep 'password:' | \
+    cut -c11-
+fi

--- a/bin/google
+++ b/bin/google
@@ -8,4 +8,4 @@ fi
 IFS='+'
 query="$*"
 
-open "https://www.google.com/#q=${query}"
+exec open "https://www.google.com/#q=${query}"

--- a/bin/iterm
+++ b/bin/iterm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Open a new iTerm session with the command given
 # as argument.
@@ -24,7 +24,7 @@
 # 9/20/2005 damonp - make sure new session opens in current window, clear screen
 # 9/15/2005 damonp - modify for iTerm usage
 
-if [ -z $3 ]; then
+if [ -z "$3" ]; then
 echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
 echo 'Launch the iTerm application in a certain folder'
 echo 'USAGE:'
@@ -41,9 +41,10 @@ if [ "x-x" = x"$1" ]; then
 fi
 
 if [[ -d "$1" ]]; then
-    WD=`cd "$1"; pwd`; shift;
+	# shellcheck disable=SC2164
+    WD=$(cd "$1"; pwd); shift;
 else
-    WD="'`pwd`'";
+    WD="'$(pwd)'";
 fi
 
 COMMAND="cd $WD"

--- a/bin/iterm
+++ b/bin/iterm
@@ -1,0 +1,78 @@
+#!/bin/sh
+#
+# Open a new iTerm session with the command given
+# as argument.
+#
+# - If there are no arguments, the new iTerm window will
+#   be opened in the current directory, i.e. as if the command
+#   would be "cd `pwd`".
+# - If the first argument is a directory, the new iTerm will
+#   "cd" into that directory before executing the remaining
+#   arguments as command.
+# - If there are arguments and the first one is not a directory,
+#   the new window will be opened in the current directory and
+#   then the arguments will be executed as command.
+# - The optional, leading "-x" flag will cause the new terminal
+#   to be closed immediately after the executed command finishes.
+#
+# original script by Marc Liyanage <http://www.entropy.ch>
+# 	designed to work with Mac OSX Terminal.app
+# iTerm modifications by Damon Parker <http://damonparker.org>
+#
+#
+# Version 1.2
+# 9/20/2005 damonp - make sure new session opens in current window, clear screen
+# 9/15/2005 damonp - modify for iTerm usage
+
+if [ -z $3 ]; then
+echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+echo 'Launch the iTerm application in a certain folder'
+echo 'USAGE:'
+echo 'iterm <foldertocdto> <nameoftab> <color>'
+echo 'iterm ~/Documents/Temp TEMP gray'
+echo 'iterm ~/Documents/Temp TEMP white'
+echo 'iterm ~/Documents/Temp TEMP blue'
+echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+exit
+fi
+
+if [ "x-x" = x"$1" ]; then
+    EXIT="; exit"; shift;
+fi
+
+if [[ -d "$1" ]]; then
+    WD=`cd "$1"; pwd`; shift;
+else
+    WD="'`pwd`'";
+fi
+
+COMMAND="cd $WD"
+TITLE="$1"
+COLOR="$2"
+
+echo "Launching iTerm with COMMAND: $COMMAND TITLE: $TITLE COLOR: $COLOR $EXIT"
+
+osascript 2>/dev/null <<EOF
+tell application "iTerm"
+  activate
+  delay 1
+  if (the first terminal exists) then
+  	set curTerminal to (the first terminal)
+	else
+		set curTerminal to (make new terminal)
+	end if
+	tell curTerminal
+			set mysession to (make new session at the end of sessions)
+			tell mysession
+  			exec command "bash -l"
+  			-- Do a \r at the end to make the command actually execute
+  			write text "$COMMAND\r $EXIT"
+  			set name to "$TITLE"
+  			set background color to "$COLOR"
+  		end tell
+	end tell
+
+	--set curTerminal to (make new terminal)
+end tell
+EOF
+exit 0

--- a/bin/markdown-open
+++ b/bin/markdown-open
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# https://github.com/rtomayko/dotfiles/blob/rtomayko/bin/markdown-open
+
+function debug() {
+  echo "$@" 1>&2
+}
+
+f=$1
+if [ -z "$f" ] || [ "$f" = "-" ] ; then
+  f=/tmp/markdown-$$.txt
+  cat > $f
+  trap "rm -f $f" 0
+fi
+
+bn=$(basename $f | sed 's:^\(.*\)\.txt$:\1:')
+html_file="$(dirname $f)/$bn.html"
+cat <<EOF > "$html_file"
+<html>
+  <head>
+  <title>$f</title>
+  <link href="https://github.com/assets/github.css" media="screen" rel="stylesheet" type="text/css" />
+  <style type="text/css">
+    div#container {
+      max-width:  852px;
+      margin:     50px auto;
+    }
+  </style>
+  <body>
+    <div id="container" class="markdown-body">
+EOF
+cat "$f" | sundown >> "$html_file"
+cat <<EOF >> "$html_file"
+    </div>
+  </body>
+</html>
+EOF
+rslt=$?
+[ $rslt != 0 ] && exit $rslt
+open "$html_file"
+sleep 0.5
+unlink "$html_file"

--- a/bin/markdown-open
+++ b/bin/markdown-open
@@ -10,7 +10,7 @@ f=$1
 if [ -z "$f" ] || [ "$f" = "-" ] ; then
   f=/tmp/markdown-$$.txt
   cat > $f
-  trap "rm -f $f" 0
+  trap 'rm -f $f' 0
 fi
 
 bn=$(basename $f | sed 's:^\(.*\)\.txt$:\1:')
@@ -29,7 +29,7 @@ cat <<EOF > "$html_file"
   <body>
     <div id="container" class="markdown-body">
 EOF
-cat "$f" | sundown >> "$html_file"
+sundown < "$f" >> "$html_file"
 cat <<EOF >> "$html_file"
     </div>
   </body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This plugin already only adds itself to `$PATH` when running on macOS, so I prefer to keep my mac-only scripts in it.

Moved `battery-prompt`, `get-wifi-password`, `iterm` and `markdown-open` scripts from the jpb zsh plugin to here.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
