### PR TITLE
zgen is stale, switch to zgenom in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ Antigen will handle cloning the plugin for you automatically the next time you s
 2. `git clone git@github.com:unixorn/tumult.plugin.zsh.git tumult`
 3. Add tumult to your plugin list - edit `~.zshrc` and change `plugins=(...)` to `plugins=(... tumult)`
 
-### [Zgen](https://github.com/tarjoilija/zgen)
+### [Zgenom](https://github.com/jandamm/zgenom)
 
-Add `zgen load unixorn/tumult.plugin.zsh` to your `.zshrc` file in the same function you're doing your other `zgen load` calls in. Zgen will handle automatically cloning the plugin for you the next time you do a `zgen save`.
+Add `zgenom load unixorn/tumult.plugin.zsh` to your `.zshrc` file in the same function you're doing your other `zgenom load` calls in. Zgen will handle automatically cloning the plugin for you the next time you do a `zgenom save`.
 
 ## License
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

zgen is stale and not getting maintained, zgenom is getting updates, use it instead.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [x] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
