### PR TITLE
Adds pubkey script

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `pbindent` | Indent the contents of the clipboard 4 spaces. With -o, write result to standard output instead of to the clipboard. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
 | `pbsed` | Run `sed`(1) on the contents of the clipboard and put the result back on the clipboard. All `sed` options and arguments are supported. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
 | `pledit` | Convert a plist to XML, run `${EDITOR}` on it, then convert it back. |
+| `pubkey` | Quick script to load an ssh public key onto your clipboard by name without you having to specify the full path to it. |
 | `quicklook` | Triggers quicklook on files so you can see what they are. |
 | `safari` | Force opening an URL with Safari |
 | `screen-resolution` | Display the screen resolution |

--- a/bin/pubkey
+++ b/bin/pubkey
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Load pubkey into clipboard.
+# I do this enough that I wanted a helper script
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+# License: Apache 2.0
+
+set -o pipefail
+
+function fail {
+  printf '%s\n' "$1" >&2  ## Write message to stderr.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+if [[ $# -eq 0 ]]; then
+  keyname="${HOME}/.ssh/id_rsa.pub"
+else
+  keyname="${HOME}/.ssh/${1}.pub"
+fi
+
+if [[ ! -r "$keyname" ]]; then
+  fail "Can't read $keyname" 
+fi
+
+pbcopy < "$keyname"
+exit $?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

`pubkey` loads the named (or `id_rsa` by default) key's public part onto your clipboard.

I do this often enough that it got tiresome doing it by hand, so I'm moving the script out of my private scripts and into tumult.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] I have read the **CONTRIBUTING** document.
