### PR TITLE
Move more functions to scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `unquarantine` | Unquarantine a file |
 | `unfuck-captive-portal` | Cope when macOs fails to render the captive portal page for joining a WIFI network by directly opening Apple's captive portal detection page with Safari. |
 | `volume` | Get/set the system volume |
+| `wifi` | Usage: `wifi on` or `wifi off` - toggles your wifi |
 | `wifi-name` | Returns the name of the WIFI network you're connected to |
 
 ## Other Useful macOS tools

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `battery-prompt` | Prints battery status as a string suitable for embedding in a prompt. |
 | `battery-time` | Show the estimated battery life. |
 | `change-wallpaper` | If you have your desktop wallpaper set to rotate through a folder of images at intervals, this will force an immediate switch |
-| `clean-xml-clip` | Clean up the XML on the clipboard |
-| `chrome` | Force opening an URL with Chrome |
 | `chrome-tabs` | Outputs the URLs for all your open Chrome tabs so you can snapshot them |
+| `chrome` | Force opening an URL with Chrome |
 | `clean-clipboard` | Converts contents of clipboard to plain text. |
 | `clean-file-context-menu` | Zaps extra entries from the file context menu. |
+| `clean-xml-clip` | Clean up the XML on the clipboard |
 | `clear-macos-font-cache` | Clears the macOS font cache, originally from [awesome-osx-command-line](https://github.com/herrbischoff/awesome-osx-command-line/blob/master/functions.md#app-icons) |
 | `column-view` | Set the current directory to column view in the Finder |
 | `diceware-password` | Generate a random but memorable passphrase using the Diceware Passphrase Algorithm. See [http://world.std.com/~reinhold/diceware.html](http://world.std.com/~reinhold/diceware.html) |
@@ -56,9 +56,9 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `eject-all` | Eject all removable disks |
 | `enable-bouncing-dock-icons` | Enable icons bouncing in your Dock |
 | `enable-ftp-server` | Enable the ftp server on a Mac |
+| `enable-network-ds-store-files` | Enable writing `.DS_Store` files to network shares (the default behavior) |
 | `enable-ssh-server` | Enable the ssh server on a Mac |
 | `enable-startup-chime` | Re-enable the boot chime |
-| `enable-network-ds-store-files` | Enable writing `.DS_Store` files to network shares (the default behavior) |
 | `evernote` | Create a new Evernote note from stdin or a file |
 | `finder-path` | Show the path to the frontmost finder window |
 | `finder-selection` | Show the paths to all items selected in the Finder, quoted so it copes with spaces in your directory or file names |
@@ -69,6 +69,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `get-iterm2-buffer` | Gets the current iterm2 window's scrollback contents |
 | `get-wifi-password` | Helper script to print the password for the wifi network you're connected to. |
 | `google` | Does a google search from the command line |
+| `hide-dotfiles` | Hide dotfiles in Finder windows to return to Apple default behavior |
 | `icon-view` | Set the current directory to icon view in the Finder |
 | `imgcat` | Display an image directly in your terminal. Only works with iTerm 2 |
 | `iterm` | Open a new `iTerm 2` session with the argument given |
@@ -104,16 +105,17 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `screen-resolution` | Display the screen resolution |
 | `set-macos-hostname` | Set the macOS name of your machine. macOS may be UNIX-based, but the Apple eccentricities mean that no, `sudo hostname newname` isn't enough if you want the new name to be visible on the network for things like File and Screen sharing. |
 | `set-mojave-disk-warning-threshold` | Mojave now pops up a warning when you're running low on disk space. Unfortunately the threshold they pick triggers a warning every couple of minutes on my MacBook Air. This script lets you set a different number of free gigabytes to warn at. |
+| `show-dotfiles` | Display dotfiles in Finder windows |
 | `speedup-apple-mail` | Speeds up Mail.app by vaccuuming the indexes - Originally from [http://www.hawkwings.net/2007/03/03/scripts-to-automate-the-mailapp-envelope-speed-trick/](http://www.hawkwings.net/2007/03/03/scripts-to-automate-the-mailapp-envelope-speed-trick/) |
 | `time-machine-log-viewer` | Dump the Time Machine logs |
 | `time-machine-throttle` | Restore default Time Machine throttle setting |
 | `time-machine-unthrottle` | Disable throttling Time Machine backups - I am having issues with very slow Time Machine backups to an SMB share. No guarantees that this will not cause _other_ subtle issues. |
 | `toggle-finder-show-dotfiles` | Toggle whether Finder shows dotfiles |
-| `unquarantine` | Unquarantine a file |
 | `unfuck-captive-portal` | Cope when macOs fails to render the captive portal page for joining a WIFI network by directly opening Apple's captive portal detection page with Safari. |
+| `unquarantine` | Unquarantine a file |
 | `volume` | Get/set the system volume |
-| `wifi` | Usage: `wifi on` or `wifi off` - toggles your wifi |
 | `wifi-name` | Returns the name of the WIFI network you're connected to |
+| `wifi` | Usage: `wifi on` or `wifi off` - toggles your wifi |
 
 ## Other Useful macOS tools
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Tumult will check to see if you're running on macOS and not add aliases or injec
 | `pbcurl` | `curl` the address in the clipboard. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
 | `pbindent` | Indent the contents of the clipboard 4 spaces. With -o, write result to standard output instead of to the clipboard. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
 | `pbsed` | Run `sed`(1) on the contents of the clipboard and put the result back on the clipboard. All `sed` options and arguments are supported. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
+| `pbsort` | Sorts the contents of the clipboard |
 | `pledit` | Convert a plist to XML, run `${EDITOR}` on it, then convert it back. |
 | `pubkey` | Quick script to load an ssh public key onto your clipboard by name without you having to specify the full path to it. |
 | `quicklook` | Triggers quicklook on files so you can see what they are. |

--- a/bin/hide-dotfiles
+++ b/bin/hide-dotfiles
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Show dotfiles in Finder
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+# License: Apache 2
+
+set -o pipefail
+
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+defaults write com.apple.Finder AppleShowAllFiles -bool true && killall Finder

--- a/bin/pbclean
+++ b/bin/pbclean
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+pbpaste | perl -pe 's/\r\n|\r/\n/g' | pbcopy

--- a/bin/pbsort
+++ b/bin/pbsort
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# sorts the contents of the clipboard
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+pbpaste | sort | pbcopy

--- a/bin/show-dotfiles
+++ b/bin/show-dotfiles
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Hide dotfiles in Finder
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+# License: Apache 2
+
+set -o pipefail
+
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+defaults write com.apple.Finder AppleShowAllFiles -bool false && killall Finder

--- a/bin/wifi
+++ b/bin/wifi
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Toggle wifi on and off from the command line
+# `wifi on` to turn wifi on, and `wifi off` to turn it off
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+# License: Apache 2
+
+set -o pipefail
+
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+# shellcheck disable=SC2046,SC2068
+networksetup -setairportpower $(networksetup -listallhardwareports | grep -A 2 'Hardware Port: Wi-Fi' | grep 'Device:' | awk '{print $2}') $@

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -55,10 +55,6 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     alias s='/usr/local/bin/subl'
   fi
 
-  # Show/hide hidden files in Finder
-  alias show-dotfiles="defaults write com.apple.Finder AppleShowAllFiles -bool true && killall Finder"
-  alias hide-dotfiles="defaults write com.apple.Finder AppleShowAllFiles -bool false && killall Finder"
-
   # Hide/show all desktop icons for presenting
   alias show-desktop-icons="defaults write com.apple.finder CreateDesktop -bool true && killall Finder"
   alias hide-desktop-icons="defaults write com.apple.finder CreateDesktop -bool false && killall Finder"

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -41,10 +41,6 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
 
   # Clipboard manipulation
   alias gpaste="pbpaste | perl -pe 's/\r\n|\r/\n/g'"
-  alias pbsort="pbpaste | sort | pbcopy"
-
-  # `wifi on` to turn wifi on, and `wifi off` to turn it off
-  alias wifi="networksetup -setairportpower $(networksetup -listallhardwareports | grep -A 2 'Hardware Port: Wi-Fi' | grep 'Device:' | awk '{print $2}')"
 
   # Add DS_Store to files ignored during completion
   fignore=(DS_Store $fignore)

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -41,7 +41,6 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
 
   # Clipboard manipulation
   alias gpaste="pbpaste | perl -pe 's/\r\n|\r/\n/g'"
-  alias pbclean="pbpaste | perl -pe 's/\r\n|\r/\n/g' | pbcopy"
   alias pbsort="pbpaste | sort | pbcopy"
 
   # `wifi on` to turn wifi on, and `wifi off` to turn it off


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Move `pbclean`, `pbsort`, `wifi`, `show-dotfiles` and `hide-dotfiles` functions into scripts to make them usable by non-ZSH shells
- Clean up README.md

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] I have read the **CONTRIBUTING** document.
