### PR TITLE
Improve override of stale macOS binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The Tumult collection is Apache 2.0 licensed. Some scripts in the `bin` director
 | `get-iterm2-buffer` | Gets the current iterm2 window's scrollback contents |
 | `get-wifi-password` | Helper script to print the password for the wifi network you're connected to. |
 | `google` | Does a google search from the command line |
+| `hide-desktop-icons` | Hide desktop icons in Finder to have a clean screen for presentations |
 | `hide-dotfiles` | Hide dotfiles in Finder windows to return to Apple default behavior |
 | `icon-view` | Set the current directory to icon view in the Finder |
 | `imgcat` | Display an image directly in your terminal. Only works with iTerm 2 |
@@ -83,7 +84,7 @@ The Tumult collection is Apache 2.0 licensed. Some scripts in the `bin` director
 | `itunesctl` | Play/Pause iTunes from terminal. |
 | `keychainctl` | CRUD for secrets in your macOS keychain - from AriaFallah's [gist](https://gist.github.com/AriaFallah/fe7b651ba2652bd301334e011749e4b2/)|
 | `kick-afp` | Restart file sharing from the CLI. I got tired of having to remote desktop in to kick the fileserver via the GUI every time Apple's file sharing got wedged, now it can be fixed over `ssh` |
-| `kick-screensharing` | Sometimes screen sharing just hangs on my Mini running 10.11. This is not new to 10.11, it was exhibiting the same annoying behavior on 10.10 and 10.9. The mini is headless and it's a pain in the ass to plug it into the TV just long enough to restart screen sharing, so I wrote this so I can fix it over ssh. |
+| `kick-screensharing` | Sometimes screen sharing just hangs on my Mini running 10.11. This is not new to 10.11, it was exhibiting the same annoying behavior on 10.10 and 10.9. The mini is headless and it's a pain in the ass to plug it into the TV just long enough to restart screen sharing, so I wrote this so I can fix it over an `ssh` connection. |
 | `kill-screensaver` | Kill the screensaver when it locks up |
 | `kill-sophos-dead` | From a slack, but won't name names lest their employer find out they kill sophos. Kill Sophos' useless scanner when it gobbles up all your CPU. People wouldn't hate antivirus software so much on macOS if it restricted itself to using one CPU core. |
 | `list-view` | Set the current directory to column view in the Finder |
@@ -112,6 +113,7 @@ The Tumult collection is Apache 2.0 licensed. Some scripts in the `bin` director
 | `screen-resolution` | Display the screen resolution |
 | `set-macos-hostname` | Set the macOS name of your machine. macOS may be UNIX-based, but the Apple eccentricities mean that no, `sudo hostname newname` isn't enough if you want the new name to be visible on the network for things like File and Screen sharing. |
 | `set-mojave-disk-warning-threshold` | Mojave now pops up a warning when you're running low on disk space. Unfortunately the threshold they pick triggers a warning every couple of minutes on my MacBook Air. This script lets you set a different number of free gigabytes to warn at. |
+| `show-desktop-icons` | Display desktop icons in Finder |
 | `show-dotfiles` | Display dotfiles in Finder windows |
 | `speedup-apple-mail` | Speeds up Mail.app by vaccuuming the indexes - Originally from [http://www.hawkwings.net/2007/03/03/scripts-to-automate-the-mailapp-envelope-speed-trick/](http://www.hawkwings.net/2007/03/03/scripts-to-automate-the-mailapp-envelope-speed-trick/) |
 | `time-machine-log-viewer` | Dump the Time Machine logs |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The Tumult collection is Apache 2.0 licensed. Some scripts in the `bin` director
 | `mac-safesleep` | Set a Mac to use safesleep mode when sleeping |
 | `mac-sleep` | Set a Mac to use the default sleep mode when sleeping |
 | `macos-frontmost-app` | Shows what application is Frontmost. |
+| `manpreview` | Renders a `man` page to PDF and opens it in Preview.app. |
 | `markdown-open` | Converts a markdown file to html and opens it in your browser |
 | `menubar-dark` | Set the menubar to be white text on black background |
 | `menubar-light` | Set the menubar to the default black text on white background style |

--- a/bin/hide-desktop-icons
+++ b/bin/hide-desktop-icons
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Hide desktop icons in Finder
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+# License: Apache 2
+
+set -o pipefail
+
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+defaults write com.apple.finder CreateDesktop -bool false && killall Finder

--- a/bin/manp
+++ b/bin/manp
@@ -1,0 +1,1 @@
+manpreview

--- a/bin/manpreview
+++ b/bin/manpreview
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Open a man page in Preview.app
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+# Check if a command exists
+has() {
+  which "$@" > /dev/null 2>&1
+}
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  fail 'Sorry, this script only works on macOS'
+fi
+
+if has ps2pdf; then
+  # shellcheck disable=SC2068
+  man -t $@ | ps2pdf - - | open -f -a Preview
+else
+  # shellcheck disable=SC2016
+  fail 'No ps2pdf in your $PATH, failing.'
+fi

--- a/bin/show-desktop-icons
+++ b/bin/show-desktop-icons
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Show desktop icons in Finder
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+# License: Apache 2
+
+set -o pipefail
+
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+defaults write com.apple.finder CreateDesktop -bool true && killall Finder

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -54,10 +54,6 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     alias s='/usr/local/bin/subl'
   fi
 
-  # Hide/show all desktop icons for presenting
-  alias show-desktop-icons="defaults write com.apple.finder CreateDesktop -bool true && killall Finder"
-  alias hide-desktop-icons="defaults write com.apple.finder CreateDesktop -bool false && killall Finder"
-
   # sound
   alias stfu="osascript -e 'set volume output muted true'"
 

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -146,10 +146,6 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     ioreg -n "AppleBluetoothHIDMouse" | grep -i "batterypercent" | sed 's/[^[:digit:]]//g'
   }
 
-  manp() {
-    man -t $* | ps2pdf - - | open -f -a Preview
-  }
-
   if has brew; then
     # homebrew alias setup
     BREW_PREFIX=$(brew --prefix)

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -30,8 +30,6 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
   alias flushdns="dscacheutil -flushcache"
   alias flushds="dscacheutil -flushcache"
   alias kickdns="dscacheutil -flushcache"
-  alias mywireless="system_profiler SPAirPortDataType | awk -F\": \" '/Current Wireless Network/{print $2}'"
-  alias open_dot='dot -Tpng | open -f -a preview'
   alias top='TERM=vt100 top'
   alias reveal='open --reveal'
 
@@ -49,6 +47,7 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
   alias cleanxmlclip='clean-xml-clip'
   alias killScreenSaver='kill-screensaver'
   alias killSS='kill-screensaver'
+  alias mywireless="wifi-name"
 
   # Sublime
   if [[ -x /usr/local/bin/subl ]]; then

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -19,10 +19,16 @@
 # without polluting your Linux environment with functions and files that
 # will fail.
 
+
 if [[ "$(uname -s)" = "Darwin" ]]; then
   # Add our plugin's bin diretory to user's path
   PLUGIN_BIN="$(dirname $0)/bin"
   export PATH=${PATH}:${PLUGIN_BIN}
+
+  # Check if a command exists
+  has() {
+    which "$@" > /dev/null 2>&1
+  }
 
   alias -g @NDL='~/Downloads/*(.om[1])'
 
@@ -144,20 +150,23 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     man -t $* | ps2pdf - - | open -f -a Preview
   }
 
-  # homebrew stuff
-  if [ -f /usr/local/Cellar/memcached/1.4.24/homebrew.mxcl.memcached.plist ]; then
-    alias memcached-load="launchctl load -w /usr/local/Cellar/memcached/1.4.24/homebrew.mxcl.memcached.plist"
-    alias memcached-unload="launchctl unload -w /usr/local/Cellar/memcached/1.4.24/homebrew.mxcl.memcached.plist"
-  fi
+  if has brew; then
+    # homebrew alias setup
+    BREW_PREFIX=$(brew --prefix)
+    if [[ -x "$BREW_PREFIX/bin/memached"]]; then
+      alias memcached-load="brew services start memcached"
+      alias memcached-unload="brew services stop memcached"
+    fi
 
-  if [ -f /usr/local/Cellar/mysql/5.7.17/homebrew.mxcl.mysql.plist ]; then
-    alias mysql-load="launchctl load -w /usr/local/Cellar/mysql/5.7.17/homebrew.mxcl.mysql.plist"
-    alias mysql-unload="launchctl unload -w /usr/local/Cellar/mysql/5.7.17/homebrew.mxcl.mysql.plist"
-  fi
+    if [[ -x "$BREW_PREFIX/bin/mysql"]]; then
+      alias mysql-load="brew services start mysql"
+      alias mysql-unload="brew services stop mysql"
+    fi
 
-  if [ -f /usr/local/Cellar/postgresql/9.6.2/homebrew.mxcl.postgresql.plist ]; then
-    alias postgres-load="launchctl load -w /usr/local/Cellar/postgresql/9.6.2/homebrew.mxcl.postgresql.plist"
-    alias postgres-unload="launchctl unload -w /usr/local/Cellar/postgresql/9.6.2/homebrew.mxcl.postgresql.plist"
+    if [[ -x "$BREW_PREFIX/bin/pg_ctl"]]; then
+      alias postgres-load="brew services start postgresql"
+      alias postgres-unload="brew services stop postgresql"
+    fi
+    unset BREW_PREFIX
   fi
-
 fi

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -63,6 +63,7 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
   # sound
   alias stfu="osascript -e 'set volume output muted true'"
 
+  # Apple has some useful stuff in places outside $PATH, so add aliases.
   if [ -x '/System/Library/CoreServices/Applications/Network Utility.app/Contents/Resources/stroke' ]; then
     alias stroke='/System/Library/CoreServices/Applications/Network\ Utility.app/Contents/Resources/stroke'
   fi
@@ -90,21 +91,6 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     command -v shasum > /dev/null && \
     alias sha1sum=$(which shasum)
 
-  # Deal with staleness in macOS userland.
-  # Apple never seems to be very current with the versions of things in userland, so
-  # we're going to set up some aliases to force user-installed versions of programs to
-  # override the stale versions in /usr.
-
-  # MySQL
-  # Use homebrew versions if present
-  if [ -x /usr/local/bin/mysql/bin/mysql ]; then
-    alias mysql="/usr/local/mysql/bin/mysql"
-  fi
-
-  if [ -x /usr/local/bin/mysql/bin/mysqladmin ]; then
-    alias mysqladmin="/usr/local/mysql/bin/mysqladmin"
-  fi
-
   # Sue me, I like vim. Got tired of different *nix stuffing it in different
   # places, so go through the usual suspects and create an alias when we find
   # it.
@@ -128,7 +114,7 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     export EDITOR='/opt/local/bin/vim'
   fi
 
-  # Same for homebrew.
+  # If they put a vim build in /usr/local/bin, they want to use that.
   if [ -x /usr/local/bin/vim ]; then
     alias vim='/usr/local/bin/vim'
     alias vi="/usr/local/bin/vim"
@@ -146,23 +132,57 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     ioreg -n "AppleBluetoothHIDMouse" | grep -i "batterypercent" | sed 's/[^[:digit:]]//g'
   }
 
+  # Deal with staleness in macOS userland.
+  # Apple never seems to be very current with the versions of things in userland, so
+  # we're going to set up some aliases to force user-installed versions of programs to
+  # override the stale versions in /usr.
+
+  # MySQL
+  # Use local versions if present
+  if [ -x /usr/local/bin/mysql/bin/mysql ]; then
+    alias mysql="/usr/local/mysql/bin/mysql"
+  fi
+
+  if [ -x /usr/local/bin/mysql/bin/mysqladmin ]; then
+    alias mysqladmin="/usr/local/mysql/bin/mysqladmin"
+  fi
+
   if has brew; then
     # homebrew alias setup
     BREW_PREFIX=$(brew --prefix)
+
+    # We prefer to use the brew installed versions of things when
+    # they're present
     if [[ -x "$BREW_PREFIX/bin/memached"]]; then
+      alias memcached="${BREW_PREFIX}/bin/memcached"
       alias memcached-load="brew services start memcached"
       alias memcached-unload="brew services stop memcached"
     fi
 
+    if [[ -x "$BREW_PREFIX/bin/mysqladmin"]]; then
+      alias mysqladmin="${BREW_PREFIX}/bin/mysqladmin"
+    fi
+
     if [[ -x "$BREW_PREFIX/bin/mysql"]]; then
+      alias mysql="${BREW_PREFIX}/bin/mysql"
       alias mysql-load="brew services start mysql"
       alias mysql-unload="brew services stop mysql"
     fi
 
     if [[ -x "$BREW_PREFIX/bin/pg_ctl"]]; then
+      alias pg_ctl="${BREW_PREFIX}/bin/pg_ctl"
       alias postgres-load="brew services start postgresql"
       alias postgres-unload="brew services stop postgresql"
     fi
+
+    # Use brew vim when present
+    if [[ -x "${BREW_PREFIX}/bin/vim" ]]; then
+      alias vim='${BREW_PREFIX}/bin/vim'
+      alias vi="${BREW_PREFIX}/bin/vim"
+      export EDITOR="${BREW_PREFIX}/bin/vim"
+      export VISUAL="${EDITOR}"
+    fi
+
     unset BREW_PREFIX
   fi
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Apple really sucks at keeping command line tooling up to date, either through fear of GPLv3 or plain old indifference.

- Update the logic that finds newer versions to check for brew binaries in `$(brew --prefix)/bin` and not just assume it will install to `/usr/local/bin`
- Add `manpreview` script
- Convert `hide-desktop-icons` and `show-desktop-icons` to scripts so non-ZSH users can use them.
- `mywireless` alias was broken by macOS updates, make it an alias to `wifi-name` which works


# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [x] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
