### PR TITLE
Add space before close of brew section's tests

### DIFF
--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -153,23 +153,23 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
 
     # We prefer to use the brew installed versions of things when
     # they're present
-    if [[ -x "$BREW_PREFIX/bin/memached"]]; then
+    if [[ -x "$BREW_PREFIX/bin/memached" ]]; then
       alias memcached="${BREW_PREFIX}/bin/memcached"
       alias memcached-load="brew services start memcached"
       alias memcached-unload="brew services stop memcached"
     fi
 
-    if [[ -x "$BREW_PREFIX/bin/mysqladmin"]]; then
+    if [[ -x "$BREW_PREFIX/bin/mysqladmin" ]]; then
       alias mysqladmin="${BREW_PREFIX}/bin/mysqladmin"
     fi
 
-    if [[ -x "$BREW_PREFIX/bin/mysql"]]; then
+    if [[ -x "$BREW_PREFIX/bin/mysql" ]]; then
       alias mysql="${BREW_PREFIX}/bin/mysql"
       alias mysql-load="brew services start mysql"
       alias mysql-unload="brew services stop mysql"
     fi
 
-    if [[ -x "$BREW_PREFIX/bin/pg_ctl"]]; then
+    if [[ -x "$BREW_PREFIX/bin/pg_ctl" ]]; then
       alias pg_ctl="${BREW_PREFIX}/bin/pg_ctl"
       alias postgres-load="brew services start postgresql"
       alias postgres-unload="brew services stop postgresql"


### PR DESCRIPTION
# Description

The missing space between the closing quote and the closing square brackets was causing a syntax error on zsh v5.8/ubuntu.

# Type of changes

- [ ] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [x] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] I have added a credit line to README.md for the script
-- There was no credits section and I don't require credit for a simple typo fix like this, but will force-push the addition if you want.
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
