### PR TITLE
Add charger-wattage script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The Tumult collection is Apache 2.0 licensed. Some scripts in the `bin` director
 | `battery-prompt` | Prints battery status as a string suitable for embedding in a prompt. |
 | `battery-time` | Show the estimated battery life. |
 | `change-wallpaper` | If you have your desktop wallpaper set to rotate through a folder of images at intervals, this will force an immediate switch |
+| `charger-wattage` | Shows the wattage of your charger. Useful for detecting bad USB-C charge cables |
 | `chrome-tabs` | Outputs the URLs for all your open Chrome tabs so you can snapshot them |
 | `chrome` | Force opening an URL with Chrome |
 | `clean-clipboard` | Converts contents of clipboard to plain text. |

--- a/bin/charger-wattage
+++ b/bin/charger-wattage
@@ -37,5 +37,6 @@ fi
 if has pmset; then
   charger-wattage
 else
+  # shellcheck disable=SC2016
   fail 'Cannot find pmset in your $PATH'
 fi

--- a/bin/charger-wattage
+++ b/bin/charger-wattage
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Script skeleton
+#
+# Copyright 2021, Your Name <yourname@yourdomain.com>
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+function charger-wattage() {
+  pmset -g ac | awk '/Wattage/ {print $3}'
+}
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+if has pmset; then
+  charger-wattage
+else
+  fail 'Cannot find pmset in your $PATH'
+fi


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

Add `charger-wattage` - this will help detect when your USB-C cable is not rating for enough wattage for your power brick, or that your monitor is not providing enough juice.

Both of those can lead to your laptop slowly draining while plugged in.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
