### PR TITLE
Add macos-dialog script

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The Tumult collection is Apache 2.0 licensed. Some scripts in the `bin` director
 | `list-view` | Set the current directory to column view in the Finder |
 | `lockscreen` | Lock the screen |
 | `mac-alert` | Display a GUI alert with `osascript` |
+| `mac-dialog` | Display a GUI dialog with `osascript` and return the user's input |
 | `mac-hibernate` | Set a Mac to use hibernate mode when sleeping |
 | `mac-notification` | Display a notification using the macOs notification manager with `osascript` |
 | `mac-safesleep` | Set a Mac to use safesleep mode when sleeping |

--- a/bin/macos-dialog
+++ b/bin/macos-dialog
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Display a dialog and return the user's input
+#
+# Copyright 2021, Joe Block <jpb@unixorn.net>
+# License: Apache 2
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+check-deps() {
+  if [[ "$(uname -s)" != 'Darwin' ]]; then
+    echo 'Sorry, this script only works on macOS'
+    exit 1
+  fi
+
+  if ! has launchctl; then
+    fail "Can't find launchctl in your PATH"
+  fi
+  
+  if ! has osascript; then
+    fail "Can't find osascript in your PATH"
+  fi
+}
+
+ask-dialog() { # $1: message $2: default text
+	message=${1:-"Message"}
+	defaultvalue=${2:-"default value"}
+	user=$(consoleUser)
+  if [[ "$user" != "" ]]; then
+    uid=$(id -u "$user")
+	
+    launchctl asuser "$uid" /usr/bin/osascript <<-EndOfScript
+			text returned of ¬
+				(display dialog "$message" ¬
+					default answer "$defaultvalue" ¬
+					buttons {"OK"} ¬
+					default button "OK")
+			EndOfScript
+  else
+    exit 1
+  fi
+}
+
+check-deps
+ask-dialog "$@"


### PR DESCRIPTION
# Description

`macos-dialog` displays a dialog with `osascript` and returns the user's input.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [ x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
