### PR TITLE
Fix vim alias setting

### DIFF
--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -174,7 +174,7 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
 
     # Use brew vim when present
     if [[ -x "${BREW_PREFIX}/bin/vim" ]]; then
-      alias vim='${BREW_PREFIX}/bin/vim'
+      alias vim="${BREW_PREFIX}/bin/vim"
       alias vi="${BREW_PREFIX}/bin/vim"
       export EDITOR="${BREW_PREFIX}/bin/vim"
       export VISUAL="${EDITOR}"


### PR DESCRIPTION
# Description

Had `'` characters where there should have been `"`, which made the vim alias include the text `${BREW_PREFIX}` instead of correctly interpolating the value.

Fixes #94

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)
- [ ] Test changes

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts are marked executable
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
