### PR TITLE
Update lockscreen for Monterey

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,8 @@
 
 <!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->
 
-- [ ] Add/update a helper script
-- [ ] A link to an external resource like a blog post or video
+- [ ] Adds/updates a helper script
+- [ ] Adds/updates a link to an external resource like a blog post or video
 - [ ] Text change (fix typos, update formatting)
 - [ ] Test changes
 
@@ -26,7 +26,7 @@
 - [ ] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
 - [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an allowed exception)
 - [ ] Scripts are marked executable
-- [ ] I have added a credit line to README.md for the script
+- [ ] I have added/updated a credit line to README.md for any scripts added or updated in this PR
 - [ ] If there was no author credit in a script added in this PR, I have added one.
 - [ ] I have confirmed that the link(s) in my PR are valid.
 - [ ] I have read the **CONTRIBUTING** document.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The Tumult collection is Apache 2.0 licensed. Some scripts in the `bin` director
 | `kill-screensaver` | Kill the screensaver when it locks up |
 | `kill-sophos-dead` | From a slack, but won't name names lest their employer find out they kill sophos. Kill Sophos' useless scanner when it gobbles up all your CPU. People wouldn't hate antivirus software so much on macOS if it restricted itself to using one CPU core. |
 | `list-view` | Set the current directory to column view in the Finder |
-| `lockscreen` | Lock the screen |
+| `lockscreen` | Start the screen saver - this only locks if your System Preferences have been set to lock the screensaver |
 | `mac-alert` | Display a GUI alert with `osascript` |
 | `mac-hibernate` | Set a Mac to use hibernate mode when sleeping |
 | `mac-notification` | Display a notification using the macOS notification manager with `osascript` |

--- a/bin/lockscreen
+++ b/bin/lockscreen
@@ -1,8 +1,40 @@
 #!/usr/bin/env bash
 
-if [ "$(uname -a | grep -ci DARWIN)" -eq 1 ]; then
-  exec /System/Library/CoreServices/"Menu Extras"/User.menu/Contents/Resources/CGSession -suspend
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return exit code $2 or 1 if unset.
+}
+
+if [[ "$(uname -s)" = "Darwin" ]]; then
+  fail "Sorry, this script only supports macOS."
+fi
+
+CORE_ENGINE='/System/Library/CoreServices/ScreenSaverEngine.app'
+FRAME_ENGINE='/System/Library/Frameworks/ScreenSaver.framework/Versions/A/Resources/ScreenSaverEngine.app'
+SCREENSAVER_ENGINE="xyzzy$$"
+
+if [[ -x "$FRAME_ENGINE" ]]; then
+  SCREENSAVER_ENGINE="$FRAME_ENGINE"
+fi
+if [[ -x "$CORE_ENGINE" ]]; then
+  SCREENSAVER_ENGINE="$CORE_ENGINE"
+fi
+
+if [[ -x "$SCREENSAVER_ENGINE" ]]; then
+  open "$SCREENSAVER_ENGINE"
 else
-  echo "This only works on macOS, sorry"
-  exit 1
+  # We can't find the screensaver app, resort to Applescript, though it could break in future revs of macOS
+  debug "Can't find ScreenSaverEngine.app, resorting to Applescript"
+  exec osascript -e 'tell application \"System Events\" to keystroke \"q\" using {command down,control down}'
 fi

--- a/bin/start-screensaver
+++ b/bin/start-screensaver
@@ -1,0 +1,1 @@
+lockscreen

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 Joseph Block <jpb@unixorn.net>
+# Copyright 2015-2022 Joseph Block <jpb@unixorn.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,11 +54,6 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
   alias killScreenSaver='kill-screensaver'
   alias killSS='kill-screensaver'
   alias mywireless="wifi-name"
-
-  # Sublime
-  if [[ -x /usr/local/bin/subl ]]; then
-    alias s='/usr/local/bin/subl'
-  fi
 
   # Apple has some useful stuff in places outside $PATH, so add aliases.
   if [ -x '/System/Library/CoreServices/Applications/Network Utility.app/Contents/Resources/stroke' ]; then


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

- `ScreenSaverEngine.app` is moved in Monterey, cope while remaining compatible with old macOS versions
- Add fallback to `osascript` if we can't find `ScreenSaverEngine.app`.  It's more brittle, but at least it's something.
- Add `start-screensaver` alias
- Note in readme that `lockscreen` only locks if System Preferences are set to lock after screen saver starts.
- Yank `Sublime Text` alias setting, leave that to end user preferences

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)
- [ ] Test changes

# Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts are marked executable
- [x] I have added/update a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
