### PR TITLE
Add `power-source` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The Tumult collection is Apache 2.0 licensed. Some scripts in the `bin` director
 | `pbsed` | Run `sed`(1) on the contents of the clipboard and put the result back on the clipboard. All `sed` options and arguments are supported. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
 | `pbsort` | Sorts the contents of the clipboard |
 | `pledit` | Convert a plist to XML, run `${EDITOR}` on it, then convert it back. |
+| `power-source` | Reports if laptop is running on battery or charger power. Has `--emoji` and `--json` options. |
 | `pubkey` | Quick script to load an ssh public key onto your clipboard by name without you having to specify the full path to it. |
 | `quicklook` | Triggers quicklook on files so you can see what they are. |
 | `restart-audio` | This fixes the "no sound" issue that happens occasionally by restarting `coreaudiod` |

--- a/bin/power-source
+++ b/bin/power-source
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022, Joe Block <jpb@unixorn.net>
+#
+# Show whether we're on battery or wall power
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+function charge-percentage() {
+  pmset -g batt | awk '/%/ {print $3}' | sed 's/;//g'
+}
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  fail "Not on macOS"
+fi
+
+# shellcheck disable=SC2143
+if [[ "$(ioreg -c AppleSmartBattery | grep '"ExternalConnected" = Yes')" ]]; then
+  power="Charger"
+else
+  power="Battery"
+fi
+
+if ! has ioreg; then
+  fail "Could not find ioreg in your PATH"
+fi
+
+function json_output() {
+  charge=$(charge-percentage)
+  cat<<END_JSON
+{
+  "power": "$power",
+  "charge": "$charge"
+}
+END_JSON
+}
+
+function emoji_output() {
+  if [[ $(pmset -g ac) == *"No adapter attached."* ]]
+  then
+    echo '🔋'
+  else
+    echo '🔌'
+  fi
+
+}
+
+case "$1" in
+  '--json')
+    json_output
+    ;;
+  '--emoji')
+    emoji_output
+    ;;
+  *)
+    echo "power: $power"
+    echo "charge: $(charge-percentage)"
+    ;;
+esac

--- a/bin/power-source
+++ b/bin/power-source
@@ -29,27 +29,20 @@ function charge-percentage() {
   pmset -g batt | awk '/%/ {print $3}' | sed 's/;//g'
 }
 
-if [[ "$(uname -s)" != "Darwin" ]]; then
-  fail "Not on macOS"
-fi
-
-# shellcheck disable=SC2143
-if [[ "$(ioreg -c AppleSmartBattery | grep '"ExternalConnected" = Yes')" ]]; then
-  power="Charger"
-else
-  power="Battery"
-fi
-
-if ! has ioreg; then
-  fail "Could not find ioreg in your PATH"
-fi
+function power-state() {
+  # shellcheck disable=SC2143
+  if [[ "$(ioreg -c AppleSmartBattery | grep '"ExternalConnected" = Yes')" ]]; then
+    echo "Charger"
+  else
+    echo "Battery"
+  fi
+}
 
 function json_output() {
-  charge=$(charge-percentage)
   cat<<END_JSON
 {
-  "power": "$power",
-  "charge": "$charge"
+  "power": "$(power-state)",
+  "charge": "$(charge-percentage)"
 }
 END_JSON
 }
@@ -57,12 +50,23 @@ END_JSON
 function emoji_output() {
   if [[ $(pmset -g ac) == *"No adapter attached."* ]]
   then
-    echo '🔋'
+    echo "$BATTERY_ICON"
   else
-    echo '🔌'
+    echo "$CHARGER_ICON"
   fi
-
 }
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  fail "Not on macOS"
+fi
+
+if ! has ioreg; then
+  fail "Could not find ioreg in your PATH"
+fi
+
+# Make the emoji easy to override
+BATTERY_ICON=${BATTERY_ICON:-"🔋"}
+CHARGER_ICON=${CHARGER_ICON:-"🔌"}
 
 case "$1" in
   '--json')
@@ -72,7 +76,7 @@ case "$1" in
     emoji_output
     ;;
   *)
-    echo "power: $power"
+    echo "power: $(power-state)"
     echo "charge: $(charge-percentage)"
     ;;
 esac


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add `power-source` script. It can be used by other scripts to detect whether a laptop is running on battery or not. Includes a `--emoji` option so it can easily be used in prompts.

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Adds/updates a helper script
- [ ] Adds/updates a link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)
- [ ] Test changes

## Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [x] Any scripts added/updated use `#!/usr/bin/env interpreter` instead of direct paths. `#!/bin/sh` is an allowed exception.
- [x] Scripts added/updated are marked executable
- [x] I have added/updated a credit line to README.md for any scripts added or updated in this PR.
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in this PR are valid.
- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/tumult.plugin.zsh/blob/main/Contributing.md) page.
