### PR TITLE
Fix typo in Oh-My-ZSH install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Antigen will handle cloning the plugin for you automatically the next time you s
 
 1. `cd ~/.oh-my-zsh/custom/plugins`
 2. `git clone git@github.com:unixorn/tumult.plugin.zsh.git tumult`
-3. Add tumult to your plugin list - edit `~.zshrc` and change `plugins=(...)` to `plugins=(... tumult)`
+3. Add tumult to your plugin list - edit `~/.zshrc` and change `plugins=(...)` to `plugins=(... tumult)`
 
 ### [Zgenom](https://github.com/jandamm/zgenom)
 


### PR DESCRIPTION
# Description

Fix typo in Oh-My-ZSH install instructions

## Type of changes

- [ ] Adds/updates a helper script
- [ ] Adds/updates a link to an external resource like a blog post or video
- [x] Text change (fix typos, update formatting)
- [ ] Test changes

## Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [ ] Any scripts added/updated use `#!/usr/bin/env interpreter` instead of direct paths. `#!/bin/sh` is an allowed exception.
- [ ] Scripts added/updated are marked executable
- [ ] I have added/updated a credit line to README.md for any scripts added or updated in this PR.
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in this PR are valid.
- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/tumult.plugin.zsh/blob/main/Contributing.md) page.
