### PR TITLE
Add `pbclean-ansi`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The Tumult collection is Apache 2.0 licensed. Some scripts in the `bin` director
 | `mute` | Mutes sound |
 | `naptime` | Put the machine to sleep |
 | `nitenite` | Make a Mac go to sleep |
+| `pbclean-ansi` | Clean ansi codes out of the clipboard |
 | `pbcurl` | `curl` the address in the clipboard. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
 | `pbindent` | Indent the contents of the clipboard 4 spaces. With -o, write result to standard output instead of to the clipboard. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |
 | `pbsed` | Run `sed`(1) on the contents of the clipboard and put the result back on the clipboard. All `sed` options and arguments are supported. Originally from Ryan Tomayko's [dotfiles](https://github.com/rtomayko) |

--- a/bin/pbclean
+++ b/bin/pbclean
@@ -1,5 +1,9 @@
 #!/bin/bash
 #
+# Copyright 2022 Joe Block <jpb@unixorn.net>
+# License: Apache 2
+
+set -o pipefail
 
 if [[ "$(uname -s)" != 'Darwin' ]]; then
   echo 'Sorry, this script only works on macOS'
@@ -7,3 +11,4 @@ if [[ "$(uname -s)" != 'Darwin' ]]; then
 fi
 
 pbpaste | perl -pe 's/\r\n|\r/\n/g' | pbcopy
+exit $?

--- a/bin/pbclean-ansi
+++ b/bin/pbclean-ansi
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+set -o pipefail
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+pbpaste | perl -pe 's/\e\[[0-9;]*m(?:\e\[K)?//g' | pbcopy
+exit $?

--- a/bin/pbindent
+++ b/bin/pbindent
@@ -6,6 +6,8 @@
 # Indent pboard text four spaces and update pboard with result. With -o,
 # write result to standard output instead of to the pboard.
 
+set -o pipefail
+
 if [[ "$(uname -s)" != 'Darwin' ]]; then
   echo 'Sorry, this script only works on macOS'
   exit 1
@@ -26,3 +28,4 @@ do
 done
 
 pbpaste | sed 's/^/    /' | $writer
+exit $?

--- a/bin/pbsed
+++ b/bin/pbsed
@@ -7,6 +7,7 @@
 #/ on the pboard. All sed options and arguments are supported.
 # shellcheck disable=SC2002
 set -e
+set -o pipefail
 
 if [[ "$(uname -s)" != 'Darwin' ]]; then
   echo 'Sorry, this script only works on macOS'
@@ -21,3 +22,4 @@ test $# -eq 0 -o "$1" = "--help" && {
 
 # pipe pboard through sed and then back again
 pbpaste | sed "$@" | pbcopy
+exit $?

--- a/bin/pbsort
+++ b/bin/pbsort
@@ -2,9 +2,12 @@
 #
 # sorts the contents of the clipboard
 
+set -o pipefail
+
 if [[ "$(uname -s)" != 'Darwin' ]]; then
   echo 'Sorry, this script only works on macOS'
   exit 1
 fi
 
 pbpaste | sort | pbcopy
+exit $?


### PR DESCRIPTION
# Description

Add `pbclean-ansi` helper script to remove ANSI color codes from the clipboard.

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Adds/updates a helper script
- [ ] Adds/updates a link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)
- [ ] Test changes

## Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [x] Any scripts added/updated use `#!/usr/bin/env interpreter` instead of direct paths. `#!/bin/sh` is an allowed exception.
- [x] Scripts added/updated are marked executable
- [x] I have added/updated a credit line to README.md for any scripts added or updated in this PR.
- [x] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in this PR are valid.
- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/tumult.plugin.zsh/blob/main/Contributing.md) page.
