### PR TITLE
Add helpers for `updatedb`, extend `PATH` for `groovy`, `go` and `npm`

### DIFF
--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -78,6 +78,20 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     alias airport='/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport'
   fi
 
+  if [[ ! -f /var/db/locate.database ]]; then
+    if [[ has launchctl ]]; then
+      if [[ -f /System/Library/LaunchDaemons/com.apple.locate.plist ]]; then
+        alias updatedb='sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.locate.plist'
+      fi
+    else
+      alias updatedb='sudo updatedb'
+    fi
+  else
+    if [[ -x /usr/libexec/locate.updatedb ]]; then
+      alias updatedb='sudo /usr/libexec/locate.updatedb'
+    fi
+  fi
+
   # Deal with some things macOS userland is missing
 
   # Canonical hex dump; some systems have this symlinked

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -30,6 +30,20 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     which "$@" > /dev/null 2>&1
   }
 
+  if has brew; then
+      if has groovy; then
+          export GROOVY_HOME="$(brew --prefix groovy)/libexec"
+      fi
+
+      if has go; then
+          path=($path "$(brew --prefix go)/bin")
+      fi
+
+      if has npm; then
+          path=($path /usr/local/share/npm/bin)
+      fi
+  fi
+
   alias -g @NDL='~/Downloads/*(.om[1])'
 
   alias eject="diskutil eject"

--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -78,6 +78,10 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
     alias airport='/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport'
   fi
 
+  if has FileMerge; then
+    alias filemerge='open -a FileMerge'
+  fi
+
   if [[ ! -f /var/db/locate.database ]]; then
     if [[ has launchctl ]]; then
       if [[ -f /System/Library/LaunchDaemons/com.apple.locate.plist ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- As installed by `brew`, `groovy`, `go` and `npm` all need more directories added to the user's `$PATH` to work as expected.
- Cope with macOS non-standard way of updating locate db by adding aliases to simplify updating the locate db on macOS

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] Adds/updates a helper script
- [ ] Adds/updates a link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)
- [ ] Test changes
- [x] Update the plugin file

## Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [ ] Any scripts added/updated use `#!/usr/bin/env interpreter` instead of direct paths. `#!/bin/sh` is an allowed exception.
- [ ] Scripts added/updated are marked executable
- [ ] I have added/updated a credit line to README.md for any scripts added or updated in this PR.
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in this PR are valid.
- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/tumult.plugin.zsh/blob/main/Contributing.md) page.
