### PR TITLE
Fix stupid mistake with `has`

### DIFF
--- a/tumult.plugin.zsh
+++ b/tumult.plugin.zsh
@@ -83,7 +83,7 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
   fi
 
   if [[ ! -f /var/db/locate.database ]]; then
-    if [[ has launchctl ]]; then
+    if has launchctl; then
       if [[ -f /System/Library/LaunchDaemons/com.apple.locate.plist ]]; then
         alias updatedb='sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.locate.plist'
       fi


### PR DESCRIPTION
## Description

Fix stupid mistake with `has` - had `[[` and `]]` which broke it.

Closes #111 

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] Adds/updates a helper script
- [x] Bugfix
- [ ] Adds/updates a link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)
- [ ] Test changes

## Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [ ] Any scripts added/updated use `#!/usr/bin/env interpreter` instead of direct paths. `#!/bin/sh` is an allowed exception.
- [ ] Scripts added/updated are marked executable
- [ ] I have added/updated a credit line to README.md for any scripts added or updated in this PR.
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in this PR are valid.
- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/tumult.plugin.zsh/blob/main/Contributing.md) page.
