### PR TITLE
Add `dns-resolvers` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The Tumult collection is Apache 2.0 licensed. Some scripts in the `bin` director
 | `disable-ssh-server` | Disable the ssh server on a Mac |
 | `disable-startup-chime` | Disable the boot chime |
 | `disturb` | Re-enable notifications in Notification Center |
+| `dns-resolvers` | macOS doesn't respect `/etc/resolve.conf`, add a helper to print what it's actually using |
 | `do-not-disturb` | Stifle notifications in Notification Center |
 | `dump-entitlements` | Dumps the [entitlements](https://developer.apple.com/documentation/bundleresources/entitlements) a given macOS binary has assigned to it |
 | `eject-all` | Eject all removable disks |

--- a/bin/dns-resolvers
+++ b/bin/dns-resolvers
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Show DNS resolver information
+#
+# Copyright 2022, Joe Block <jpb@unixorn.net>
+
+set -o pipefail
+
+case $(uname) in
+  Darwin)
+    exec scutil --dns | awk '/^(DNS|resolver|  (search|nameserver|domain))/'
+    ;;
+  Linux)
+    exec cat /etc/resolv.conf
+    ;;
+esac


### PR DESCRIPTION
# Description

I can never remember the right `scutil` command to show the resolvers macOS is using, so add a helper to print them.

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Adds/updates a helper script
- [ ] Adds/updates a link to an external resource like a blog post or video
- [ ] Text change (fix typos, update formatting)
- [ ] Test changes

## Copyright Assignment

- [x] This document is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [x] Any scripts added/updated use `#!/usr/bin/env interpreter` instead of direct paths. `#!/bin/sh` is an allowed exception.
- [x] Scripts added/updated are marked executable
- [x] I have added/updated a credit line to README.md for any scripts added or updated in this PR.
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in this PR are valid.
- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/tumult.plugin.zsh/blob/main/Contributing.md) page.
