### PR TITLE
Tidy up scripts

### DIFF
--- a/bin/battery-percentage
+++ b/bin/battery-percentage
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o pipefail
+
 if [[ "$(uname -s)" != 'Darwin' ]]; then
   echo 'Sorry, this script only works on macOS'
   exit 1
@@ -20,3 +22,4 @@ fi
 
 # Print battery percentage
 pmset -g batt | grep -E "([0-9]+\%).*" -o --colour=auto | cut -f1 -d';'
+exit $?

--- a/bin/battery-time
+++ b/bin/battery-time
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o pipefail
+
 if [[ "$(uname -s)" != 'Darwin' ]]; then
   echo 'Sorry, this script only works on macOS'
   exit 1
@@ -20,3 +22,4 @@ fi
 
 # Print system's estimate of battery time remaining
 pmset -g batt | grep -E "([0-9]+\%).*" -o --colour=auto | cut -f3 -d';'
+exit $?

--- a/bin/charger-wattage
+++ b/bin/charger-wattage
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Script skeleton
+# Show the wattage of your charger
 #
-# Copyright 2021, Your Name <yourname@yourdomain.com>
+# Copyright 2021, Joe Block <jpb@unixorn.net>
 
 set -o pipefail
 if [[ -n "$DEBUG" ]]; then

--- a/bin/clean-xml-clip
+++ b/bin/clean-xml-clip
@@ -11,4 +11,15 @@ if [[ "$(uname -s)" != 'Darwin' ]]; then
   exit 1
 fi
 
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+if ! has tidy; then
+  echo 'tidy not found in $PATH!'
+  exit 13
+fi
+
 pbpaste | tidy -xml -wrap 0 | pbcopy
+exit $?

--- a/bin/column-view
+++ b/bin/column-view
@@ -21,7 +21,7 @@ if [[ "$(uname -s)" != 'Darwin' ]]; then
   exit 1
 fi
 
-osascript <<EOT
+exec osascript <<EOT
   set cwd to do shell script "pwd"
   tell application "Finder"
     if (${1-1} <= (count Finder windows)) then

--- a/bin/diceware-password
+++ b/bin/diceware-password
@@ -85,7 +85,7 @@ STR
     @num_rounds.times do
       ary = [random_word, random_special, random_word, random_special, random_word]
       phrase = ary.join('')
-      
+
       phrase = munge_case(phrase) if @case
 
       phrases << phrase
@@ -7876,3 +7876,18 @@ __END__
 66664	?
 66665	??
 66666	@
+66667 ziggurat
+66668 godzilla
+66669 rodan
+66670 gammera
+66671 ultraman
+66672 cthulhu
+66673 shoggoth
+66674 mordor
+66675 gandalf
+66676 frodo
+66677 boromir
+66678 saruman
+66679 balrog
+66680 elboreth
+66681 yendor

--- a/bin/disable-bouncing-dock-icons
+++ b/bin/disable-bouncing-dock-icons
@@ -6,5 +6,10 @@
 
 set -o pipefail
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 defaults write com.apple.dock no-bouncing -bool TRUE
 killall Dock

--- a/bin/disable-crash-reports
+++ b/bin/disable-crash-reports
@@ -4,5 +4,10 @@
 #
 # Copyright 2023, Joe Block <jpb@unixorn.net>
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 echo "You can re-enable crash reports with 'enable-crash-reports'"
 exec defaults write com.apple.CrashReporterDialogType none

--- a/bin/disable-network-ds-store-files
+++ b/bin/disable-network-ds-store-files
@@ -4,4 +4,9 @@
 #
 # Copyright 2020, Joe Block <jpb@unixorn.net>
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 exec defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool TRUE

--- a/bin/disturb
+++ b/bin/disturb
@@ -6,6 +6,11 @@
 
 set -o pipefail
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 #
 # Based on an answer by Jacques Rioux  on discussions.apple.com.
 #

--- a/bin/dns-resolvers
+++ b/bin/dns-resolvers
@@ -8,7 +8,8 @@ set -o pipefail
 
 case $(uname) in
   Darwin)
-    exec scutil --dns | awk '/^(DNS|resolver|  (search|nameserver|domain))/'
+    scutil --dns | awk '/^(DNS|resolver|  (search|nameserver|domain))/'
+    exit $?
     ;;
   Linux)
     exec cat /etc/resolv.conf

--- a/bin/do-not-disturb
+++ b/bin/do-not-disturb
@@ -9,6 +9,12 @@
 # Based on an answer by Jacques Rioux  on discussions.apple.com.
 #
 # https://discussions.apple.com/thread/7520296?start=0&tstart=0
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 now=$(date -u "+%Y-%m-%dT%TZ")
 defaults -currentHost write com.apple.notificationcenterui doNotDisturb -bool TRUE
 defaults -currentHost write com.apple.notificationcenterui doNotDisturbDate -date "$now"

--- a/bin/dump-entitlements
+++ b/bin/dump-entitlements
@@ -14,6 +14,10 @@ IFS=$'\n\t'
 # This makes bash consider newlines and tabs as separating words
 # See: http://redsymbol.net/articles/unofficial-bash-strict-mode/
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
 
 function usage {
   echo

--- a/bin/enable-bouncing-dock-icons
+++ b/bin/enable-bouncing-dock-icons
@@ -6,5 +6,10 @@
 
 set -o pipefail
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 defaults write com.apple.dock no-bouncing -bool FALSE
 killall Dock

--- a/bin/enable-crash-reports
+++ b/bin/enable-crash-reports
@@ -4,4 +4,9 @@
 #
 # Copyright 2023, Joe Block <jpb@unixorn.net>
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 exec defaults write com.apple.CrashReporterDialogType crashreport

--- a/bin/enable-network-ds-store-files
+++ b/bin/enable-network-ds-store-files
@@ -4,4 +4,9 @@
 #
 # Copyright 2020, Joe Block <jpb@unixorn.net>
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 exec defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool FALSE

--- a/bin/focusmode-disable
+++ b/bin/focusmode-disable
@@ -1,4 +1,9 @@
 #!/bin/bash
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 # Disable Focus Mode (aka Single App Mode)
 defaults write com.apple.dock single-app -bool false && killall Dock

--- a/bin/focusmode-enable
+++ b/bin/focusmode-enable
@@ -1,4 +1,9 @@
 #!/bin/bash
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 # Enable Focus Mode (aka Single App Mode)
 defaults write com.apple.dock single-app -bool true && killall Dock

--- a/bin/get-wallpaper-path
+++ b/bin/get-wallpaper-path
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-osascript -e 'tell application "Finder"
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
+exec osascript -e 'tell application "Finder"
 	set wall to desktop picture as alias
 	set wallpath to POSIX path of wall
 end tell'

--- a/bin/get-wifi-password
+++ b/bin/get-wifi-password
@@ -13,4 +13,6 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
   security find-generic-password -ga "$1" 2>&1 | \
     grep 'password:' | \
     cut -c11-
+else
+  echo "This only works on macOS"
 fi

--- a/bin/interface-style
+++ b/bin/interface-style
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Script skeleton
+# Read whether macOS is set to light or dark UI
 #
-# Copyright 2022, Your Name <yourname@yourdomain.com>
+# Copyright 2022, Joe Block <jpb@unixorn.net>
 
 set -o pipefail
 if [[ -n "$DEBUG" ]]; then
@@ -39,5 +39,10 @@ function interface-style() {
     echo "Light"
   fi
 }
+
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
 
 interface-style

--- a/bin/keychainctl
+++ b/bin/keychainctl
@@ -4,6 +4,11 @@
 
 KEYCHAIN=${KEYCHAIN:-"secrets.keychain"}
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 main () {
   if [[ -z "$1" ]]; then
     print_usage

--- a/bin/macos-major-version
+++ b/bin/macos-major-version
@@ -6,5 +6,9 @@
 # every major rev or so. Add a helper to standardize detecting the rev
 
 set -o pipefail
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
 
 sw_vers -productVersion | awk -F '.' '{print $1 "." $2}'

--- a/bin/markdown-open
+++ b/bin/markdown-open
@@ -2,6 +2,11 @@
 #
 # https://github.com/rtomayko/dotfiles/blob/rtomayko/bin/markdown-open
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 function debug() {
   echo "$@" 1>&2
 }

--- a/bin/mergepdfs
+++ b/bin/mergepdfs
@@ -6,6 +6,11 @@
 
 set -o pipefail
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 usage() {
   echo "Usage:"
   # shellcheck disable=SC2086

--- a/bin/quicklook
+++ b/bin/quicklook
@@ -9,5 +9,10 @@ if [[ -n "$DEBUG" ]]; then
   set -x
 fi
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 # shellcheck disable=SC2048,SC2086
 (( $# > 0 )) && qlmanage -p $* &>/dev/null &

--- a/bin/smart-quote-disable
+++ b/bin/smart-quote-disable
@@ -4,5 +4,9 @@
 #
 # Copyright 2021, Joe Block <jpb@unixorn.net>
 
-exec defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
 
+exec defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false

--- a/bin/smart-quote-enable
+++ b/bin/smart-quote-enable
@@ -4,5 +4,9 @@
 #
 # Copyright 2021, Joe Block <jpb@unixorn.net>
 
-exec defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool true
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
 
+exec defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool true

--- a/bin/time-machine-log-viewer
+++ b/bin/time-machine-log-viewer
@@ -9,5 +9,10 @@ if [[ -n "$DEBUG" ]]; then
   set -x
 fi
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 # show --last 6h instead of stream will only dispay the last 6h, then quit.
 log stream --color always --predicate 'subsystem == "com.apple.TimeMachine"' --info | grep -v ' SmCp'

--- a/bin/time-machine-throttle
+++ b/bin/time-machine-throttle
@@ -4,4 +4,9 @@
 #
 # Copyright 2021, Joe Block <jpb@unixorn.ne>
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 exec sudo sysctl debug.lowpri_throttle_enabled=1

--- a/bin/time-machine-unthrottle
+++ b/bin/time-machine-unthrottle
@@ -4,4 +4,9 @@
 #
 # Copyright 2021, Joe Block <jpb@unixorn.ne>
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+  echo 'Sorry, this script only works on macOS'
+  exit 1
+fi
+
 exec sudo sysctl debug.lowpri_throttle_enabled=0


### PR DESCRIPTION
# Description

- Added checks that we're running on macOS to a bunch of scripts that were missing them
- I forgot to edit the header lines in a bunch of `newscript`-generated scripts, so fix those
- Added execs to several scripts that were swallowing exit codes

## Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] Adds/updates a helper script
- [ ] Adds/updates a link to an external resource like a blog post or video
- [x] Text change (fix typos, update formatting)
- [ ] Test changes

## Copyright Assignment

- [x] This repository is covered by the [Apache License](https://github.com/unixorn/tumult.plugin.zsh/blob/master/LICENSE), and I agree to contribute this PR under the terms of that license.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [x] Any scripts added/updated use `#!/usr/bin/env interpreter` instead of direct paths. `#!/bin/sh` is an allowed exception.
- [x] Scripts added/updated are marked executable
- [ ] I have added/updated a credit line to README.md for any scripts added or updated in this PR.
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in this PR are valid.
- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/tumult.plugin.zsh/blob/main/Contributing.md) page.
